### PR TITLE
De-globalization

### DIFF
--- a/TOM_Page.lua
+++ b/TOM_Page.lua
@@ -1,29 +1,31 @@
-local currentPage = 1
---local numPages = math.ceil(TOM_NumSavedOutfits() / 8)
+local addonName, TOM = ...
 
-function TOM_SetPageText()
-	TOM_OutfitContainer.PageText:SetText(string.format("Page %d / %d", currentPage, TOM_NumPages()))
+local currentPage = 1
+--local numPages = math.ceil(TOM.NumSavedOutfits() / 8)
+
+function TOM.SetPageText()
+	TOM.OutfitContainer.PageText:SetText(string.format("Page %d / %d", currentPage, TOM.NumPages()))
 end
 
-function TOM_GetCurrentPage()
+function TOM.GetCurrentPage()
 	return currentPage
 end
 
-function TOM_NumPages()
-	return math.max(1, math.ceil(TOM_NumSavedOutfits() / 8))
+function TOM.NumPages()
+	return math.max(1, math.ceil(TOM.NumSavedOutfits() / 8))
 end
 
-function TOM_SetPageButtons()
+function TOM.SetPageButtons()
 	if currentPage == 1 then
-		TOM_PreviousPageButton:SetEnabled(false)
-		if TOM_NumPages() > 1 then
-			TOM_NextPageButton:SetEnabled(true)
+		TOM.PreviousPageButton:SetEnabled(false)
+		if TOM.NumPages() > 1 then
+			TOM.NextPageButton:SetEnabled(true)
 		end
 	end
-	if currentPage == TOM_NumPages() then
-		TOM_NextPageButton:SetEnabled(false)
+	if currentPage == TOM.NumPages() then
+		TOM.NextPageButton:SetEnabled(false)
 	else
-		TOM_NextPageButton:SetEnabled(true)
+		TOM.NextPageButton:SetEnabled(true)
 	end
 end
 
@@ -31,36 +33,36 @@ local function TOM_PreviousPageButton_OnClick(self, button, down)
 	if button ~= "LeftButton" then return end
 	if currentPage > 1 then
 		currentPage = currentPage - 1
-		TOM_NextPageButton:SetEnabled(true)
+		TOM.NextPageButton:SetEnabled(true)
 	end
-	if currentPage == 1 then TOM_PreviousPageButton:SetEnabled(false) end
-	TOM_OutfitContainer_OnShow()
-	TOM_SetPageText()
+	if currentPage == 1 then TOM.PreviousPageButton:SetEnabled(false) end
+	TOM.OutfitContainer_OnShow()
+	TOM.SetPageText()
 end
 
 local function TOM_NextPageButton_OnClick(self, button, down)
 	if button ~= "LeftButton" then return end
-	if currentPage < math.ceil(TOM_NumSavedOutfits() / 8) then
+	if currentPage < math.ceil(TOM.NumSavedOutfits() / 8) then
 		currentPage = currentPage + 1
-		TOM_PreviousPageButton:SetEnabled(true)
+		TOM.PreviousPageButton:SetEnabled(true)
 	end
-	if currentPage == TOM_NumPages() then TOM_NextPageButton:SetEnabled(false) end
-	TOM_OutfitContainer_OnShow()
-	TOM_SetPageText()
+	if currentPage == TOM.NumPages() then TOM.NextPageButton:SetEnabled(false) end
+	TOM.OutfitContainer_OnShow()
+	TOM.SetPageText()
 end
 
-TOM_PreviousPageButton = CreateFrame("Button", "TOM_PreviousPageButton", TOM_OutfitContainer, "CollectionsPrevPageButton")
-TOM_PreviousPageButton:ClearAllPoints()
-TOM_PreviousPageButton:SetPoint("CENTER", TOM_OutfitContainer, "BOTTOM", 20, 40)
-TOM_PreviousPageButton:SetScript("OnClick", TOM_PreviousPageButton_OnClick)
-TOM_PreviousPageButton:SetEnabled(false)
+TOM.PreviousPageButton = CreateFrame("Button", nil, TOM.OutfitContainer, "CollectionsPrevPageButton")
+TOM.PreviousPageButton:ClearAllPoints()
+TOM.PreviousPageButton:SetPoint("CENTER", TOM.OutfitContainer, "BOTTOM", 20, 40)
+TOM.PreviousPageButton:SetScript("OnClick", TOM_PreviousPageButton_OnClick)
+TOM.PreviousPageButton:SetEnabled(false)
 
-TOM_NextPageButton = CreateFrame("Button", "TOM_NextPageButton", TOM_OutfitContainer, "CollectionsNextPageButton")
-TOM_NextPageButton:ClearAllPoints()
-TOM_NextPageButton:SetPoint("CENTER", TOM_OutfitContainer, "BOTTOM", 60, 40)
-TOM_NextPageButton:SetScript("OnClick", TOM_NextPageButton_OnClick)
-if TOM_NumSavedOutfits() <= 8 then TOM_NextPageButton:SetEnabled(false) end -- feels hacky
+TOM.NextPageButton = CreateFrame("Button", nil, TOM.OutfitContainer, "CollectionsNextPageButton")
+TOM.NextPageButton:ClearAllPoints()
+TOM.NextPageButton:SetPoint("CENTER", TOM.OutfitContainer, "BOTTOM", 60, 40)
+TOM.NextPageButton:SetScript("OnClick", TOM_NextPageButton_OnClick)
+if TOM.NumSavedOutfits() <= 8 then TOM.NextPageButton:SetEnabled(false) end -- feels hacky
 
-TOM_OutfitContainer.PageText = TOM_OutfitContainer:CreateFontString("TOM_PageText", "OVERLAY", "GameTooltipText")
-TOM_OutfitContainer.PageText:ClearAllPoints()
-TOM_OutfitContainer.PageText:SetPoint("CENTER", TOM_OutfitContainer, "BOTTOM", -40, 40)
+TOM.OutfitContainer.PageText = TOM.OutfitContainer:CreateFontString(nil, "OVERLAY", "GameTooltipText")
+TOM.OutfitContainer.PageText:ClearAllPoints()
+TOM.OutfitContainer.PageText:SetPoint("CENTER", TOM.OutfitContainer, "BOTTOM", -40, 40)

--- a/TOM_PreviewModelFrame.lua
+++ b/TOM_PreviewModelFrame.lua
@@ -1,6 +1,9 @@
+local addonName, TOM = ...
+-- this module could be refactored to a row by column generator method
+
 TOM.previewModelFrames = {}
 
-function TOM_GetPreviewModelFrame(row, column)
+function TOM.GetPreviewModelFrame(row, column)
 	if row < 1 or row > 2 then return nil end
 	if column < 1 or column > 4 then return nil end
 	return TOM.previewModelFrames[(row-1)*4+column]
@@ -9,223 +12,164 @@ end
 ------------------
 --ROW 1 COLUMN 1--
 ------------------
-TOM_PreviewModel_R1C1 = CreateFrame("DressUpModel", "TOM_PreviewModel_R1C1", TOM_OutfitContainer, "BackdropTemplate")
-TOM_PreviewModel_R1C1:SetSize(125, 175)
-TOM_PreviewModel_R1C1:SetBackdrop({bgFile="Interface/Tooltips/UI-Tooltip-Background",
-							edgeFile="Interface/Tooltips/UI-Tooltip-Border",
-							tile=true,
-							tileSize=16,
-							edgeSize=16,
-							insets={left=1,
-									right=1,
-									top=1,
-									bottom=1}
-})
-TOM_PreviewModel_R1C1:SetBackdropColor(0, 0, 0, 1)
-TOM_PreviewModel_R1C1:Show()
-TOM_PreviewModel_R1C1:SetPoint("CENTER", TOM_OutfitContainer, "CENTER", -200, 125)
-TOM_PreviewModel_R1C1:EnableMouse(true)
-TOM_PreviewModel_R1C1:SetScript("OnMouseDown", TOM_PreviewModel_OnMouseDown)
-TOM_PreviewModel_R1C1:SetUnit("player")
-TOM_PreviewModel_R1C1.OutfitName = TOM_PreviewModel_R1C1:CreateFontString(nil, "OVERLAY", "GameTooltipText")
-TOM_PreviewModel_R1C1.OutfitName:ClearAllPoints()
-TOM_PreviewModel_R1C1.OutfitName:SetPoint("BOTTOM", TOM_PreviewModel_R1C1, "BOTTOM", 0, 10)
-TOM_PreviewModel_R1C1.OutfitName:Hide()
-TOM_PreviewModel_R1C1:Hide()
-TOM.previewModelFrames[1] = TOM_PreviewModel_R1C1
+-- small memory gains when we pass a reference to an array than instantiating separate anonymous arrays
+local backdrop = {
+	bgFile="Interface/Tooltips/UI-Tooltip-Background",
+	edgeFile="Interface/Tooltips/UI-Tooltip-Border",
+	tile=true,
+	tileSize=16,
+	edgeSize=16,
+	insets={
+		left=1,
+		right=1,
+		top=1,
+		bottom=1}
+}
+TOM.PreviewModel_R1C1 = CreateFrame("DressUpModel", nil, TOM.OutfitContainer, "BackdropTemplate")
+TOM.PreviewModel_R1C1:SetSize(125, 175)
+TOM.PreviewModel_R1C1:SetBackdrop()
+TOM.PreviewModel_R1C1:SetBackdropColor(0, 0, 0, 1)
+TOM.PreviewModel_R1C1:Show()
+TOM.PreviewModel_R1C1:SetPoint("CENTER", TOM.OutfitContainer, "CENTER", -200, 125)
+TOM.PreviewModel_R1C1:EnableMouse(true)
+TOM.PreviewModel_R1C1:SetScript("OnMouseDown", TOM.PreviewModel_OnMouseDown)
+TOM.PreviewModel_R1C1:SetUnit("player")
+TOM.PreviewModel_R1C1.OutfitName = TOM.PreviewModel_R1C1:CreateFontString(nil, "OVERLAY", "GameTooltipText")
+TOM.PreviewModel_R1C1.OutfitName:ClearAllPoints()
+TOM.PreviewModel_R1C1.OutfitName:SetPoint("BOTTOM", TOM.PreviewModel_R1C1, "BOTTOM", 0, 10)
+TOM.PreviewModel_R1C1.OutfitName:Hide()
+TOM.PreviewModel_R1C1:Hide()
+TOM.previewModelFrames[1] = TOM.PreviewModel_R1C1
 
 ------------------
 --ROW 1 COLUMN 2--
 ------------------
-TOM_PreviewModel_R1C2 = CreateFrame("DressUpModel", "TOM_PreviewModel_R1C2", TOM_OutfitContainer, "BackdropTemplate")
-TOM_PreviewModel_R1C2:SetSize(125, 175)
-TOM_PreviewModel_R1C2:SetBackdrop({bgFile="Interface/Tooltips/UI-Tooltip-Background",
-							edgeFile="Interface/Tooltips/UI-Tooltip-Border",
-							tile=true,
-							tileSize=16,
-							edgeSize=16,
-							insets={left=1,
-									right=1,
-									top=1,
-									bottom=1}
-})
-TOM_PreviewModel_R1C2:SetBackdropColor(0, 0, 0, 1)
-TOM_PreviewModel_R1C2:Show()
-TOM_PreviewModel_R1C2:SetPoint("CENTER", TOM_OutfitContainer, "CENTER", -65, 125)
-TOM_PreviewModel_R1C2:EnableMouse(true)
-TOM_PreviewModel_R1C2:SetScript("OnMouseDown", TOM_PreviewModel_OnMouseDown)
-TOM_PreviewModel_R1C2:SetUnit("player")
-TOM_PreviewModel_R1C2.OutfitName = TOM_PreviewModel_R1C2:CreateFontString(nil, "OVERLAY", "GameTooltipText")
-TOM_PreviewModel_R1C2.OutfitName:ClearAllPoints()
-TOM_PreviewModel_R1C2.OutfitName:SetPoint("BOTTOM", TOM_PreviewModel_R1C2, "BOTTOM", 0, 10)
-TOM_PreviewModel_R1C2.OutfitName:Hide()
-TOM_PreviewModel_R1C2:Hide()
-TOM.previewModelFrames[2] = TOM_PreviewModel_R1C2
+TOM.PreviewModel_R1C2 = CreateFrame("DressUpModel", nil, TOM.OutfitContainer, "BackdropTemplate")
+TOM.PreviewModel_R1C2:SetSize(125, 175)
+TOM.PreviewModel_R1C2:SetBackdrop(backdrop)
+TOM.PreviewModel_R1C2:SetBackdropColor(0, 0, 0, 1)
+TOM.PreviewModel_R1C2:Show()
+TOM.PreviewModel_R1C2:SetPoint("CENTER", TOM.OutfitContainer, "CENTER", -65, 125)
+TOM.PreviewModel_R1C2:EnableMouse(true)
+TOM.PreviewModel_R1C2:SetScript("OnMouseDown", TOM.PreviewModel_OnMouseDown)
+TOM.PreviewModel_R1C2:SetUnit("player")
+TOM.PreviewModel_R1C2.OutfitName = TOM.PreviewModel_R1C2:CreateFontString(nil, "OVERLAY", "GameTooltipText")
+TOM.PreviewModel_R1C2.OutfitName:ClearAllPoints()
+TOM.PreviewModel_R1C2.OutfitName:SetPoint("BOTTOM", TOM.PreviewModel_R1C2, "BOTTOM", 0, 10)
+TOM.PreviewModel_R1C2.OutfitName:Hide()
+TOM.PreviewModel_R1C2:Hide()
+TOM.previewModelFrames[2] = TOM.PreviewModel_R1C2
 
 ------------------
 --ROW 1 COLUMN 3--
 ------------------
-TOM_PreviewModel_R1C3 = CreateFrame("DressUpModel", "TOM_PreviewModel_R1C3", TOM_OutfitContainer, "BackdropTemplate")
-TOM_PreviewModel_R1C3:SetSize(125, 175)
-TOM_PreviewModel_R1C3:SetBackdrop({bgFile="Interface/Tooltips/UI-Tooltip-Background",
-							edgeFile="Interface/Tooltips/UI-Tooltip-Border",
-							tile=true,
-							tileSize=16,
-							edgeSize=16,
-							insets={left=1,
-									right=1,
-									top=1,
-									bottom=1}
-})
-TOM_PreviewModel_R1C3:SetBackdropColor(0, 0, 0, 1)
-TOM_PreviewModel_R1C3:Show()
-TOM_PreviewModel_R1C3:SetPoint("CENTER", TOM_OutfitContainer, "CENTER", 65, 125)
-TOM_PreviewModel_R1C3:EnableMouse(true)
-TOM_PreviewModel_R1C3:SetScript("OnMouseDown", TOM_PreviewModel_OnMouseDown)
-TOM_PreviewModel_R1C3:SetUnit("player")
-TOM_PreviewModel_R1C3.OutfitName = TOM_PreviewModel_R1C3:CreateFontString(nil, "OVERLAY", "GameTooltipText")
-TOM_PreviewModel_R1C3.OutfitName:ClearAllPoints()
-TOM_PreviewModel_R1C3.OutfitName:SetPoint("BOTTOM", TOM_PreviewModel_R1C3, "BOTTOM", 0, 10)
-TOM_PreviewModel_R1C3.OutfitName:Hide()
-TOM_PreviewModel_R1C3:Hide()
-TOM.previewModelFrames[3] = TOM_PreviewModel_R1C3
+TOM.PreviewModel_R1C3 = CreateFrame("DressUpModel", nil, TOM.OutfitContainer, "BackdropTemplate")
+TOM.PreviewModel_R1C3:SetSize(125, 175)
+TOM.PreviewModel_R1C3:SetBackdrop(backdrop)
+TOM.PreviewModel_R1C3:SetBackdropColor(0, 0, 0, 1)
+TOM.PreviewModel_R1C3:Show()
+TOM.PreviewModel_R1C3:SetPoint("CENTER", TOM.OutfitContainer, "CENTER", 65, 125)
+TOM.PreviewModel_R1C3:EnableMouse(true)
+TOM.PreviewModel_R1C3:SetScript("OnMouseDown", TOM.PreviewModel_OnMouseDown)
+TOM.PreviewModel_R1C3:SetUnit("player")
+TOM.PreviewModel_R1C3.OutfitName = TOM.PreviewModel_R1C3:CreateFontString(nil, "OVERLAY", "GameTooltipText")
+TOM.PreviewModel_R1C3.OutfitName:ClearAllPoints()
+TOM.PreviewModel_R1C3.OutfitName:SetPoint("BOTTOM", TOM.PreviewModel_R1C3, "BOTTOM", 0, 10)
+TOM.PreviewModel_R1C3.OutfitName:Hide()
+TOM.PreviewModel_R1C3:Hide()
+TOM.previewModelFrames[3] = TOM.PreviewModel_R1C3
 
 ------------------
 --ROW 1 COLUMN 4--
 ------------------
-TOM_PreviewModel_R1C4 = CreateFrame("DressUpModel", "TOM_PreviewModel_R1C4", TOM_OutfitContainer, "BackdropTemplate")
-TOM_PreviewModel_R1C4:SetSize(125, 175)
-TOM_PreviewModel_R1C4:SetBackdrop({bgFile="Interface/Tooltips/UI-Tooltip-Background",
-							edgeFile="Interface/Tooltips/UI-Tooltip-Border",
-							tile=true,
-							tileSize=16,
-							edgeSize=16,
-							insets={left=1,
-									right=1,
-									top=1,
-									bottom=1}
-})
-TOM_PreviewModel_R1C4:SetBackdropColor(0, 0, 0, 1)
-TOM_PreviewModel_R1C4:Show()
-TOM_PreviewModel_R1C4:SetPoint("CENTER", TOM_OutfitContainer, "CENTER", 200, 125)
-TOM_PreviewModel_R1C4:EnableMouse(true)
-TOM_PreviewModel_R1C4:SetScript("OnMouseDown", TOM_PreviewModel_OnMouseDown)
-TOM_PreviewModel_R1C4:SetUnit("player")
-TOM_PreviewModel_R1C4.OutfitName = TOM_PreviewModel_R1C4:CreateFontString(nil, "OVERLAY", "GameTooltipText")
-TOM_PreviewModel_R1C4.OutfitName:ClearAllPoints()
-TOM_PreviewModel_R1C4.OutfitName:SetPoint("BOTTOM", TOM_PreviewModel_R1C4, "BOTTOM", 0, 10)
-TOM_PreviewModel_R1C4.OutfitName:Hide()
-TOM_PreviewModel_R1C4:Hide()
-TOM.previewModelFrames[4] = TOM_PreviewModel_R1C4
+TOM.PreviewModel_R1C4 = CreateFrame("DressUpModel", nil, TOM.OutfitContainer, "BackdropTemplate")
+TOM.PreviewModel_R1C4:SetSize(125, 175)
+TOM.PreviewModel_R1C4:SetBackdrop(backdrop)
+TOM.PreviewModel_R1C4:SetBackdropColor(0, 0, 0, 1)
+TOM.PreviewModel_R1C4:Show()
+TOM.PreviewModel_R1C4:SetPoint("CENTER", TOM.OutfitContainer, "CENTER", 200, 125)
+TOM.PreviewModel_R1C4:EnableMouse(true)
+TOM.PreviewModel_R1C4:SetScript("OnMouseDown", TOM.PreviewModel_OnMouseDown)
+TOM.PreviewModel_R1C4:SetUnit("player")
+TOM.PreviewModel_R1C4.OutfitName = TOM.PreviewModel_R1C4:CreateFontString(nil, "OVERLAY", "GameTooltipText")
+TOM.PreviewModel_R1C4.OutfitName:ClearAllPoints()
+TOM.PreviewModel_R1C4.OutfitName:SetPoint("BOTTOM", TOM.PreviewModel_R1C4, "BOTTOM", 0, 10)
+TOM.PreviewModel_R1C4.OutfitName:Hide()
+TOM.PreviewModel_R1C4:Hide()
+TOM.previewModelFrames[4] = TOM.PreviewModel_R1C4
 
 ------------------
 --ROW 2 COLUMN 1--
 ------------------
-TOM_PreviewModel_R2C1 = CreateFrame("DressUpModel", "TOM_PreviewModel_R2C1", TOM_OutfitContainer, "BackdropTemplate")
-TOM_PreviewModel_R2C1:SetSize(125, 175)
-TOM_PreviewModel_R2C1:SetBackdrop({bgFile="Interface/Tooltips/UI-Tooltip-Background",
-							edgeFile="Interface/Tooltips/UI-Tooltip-Border",
-							tile=true,
-							tileSize=16,
-							edgeSize=16,
-							insets={left=1,
-									right=1,
-									top=1,
-									bottom=1}
-})
-TOM_PreviewModel_R2C1:SetBackdropColor(0, 0, 0, 1)
-TOM_PreviewModel_R2C1:Show()
-TOM_PreviewModel_R2C1:SetPoint("CENTER", TOM_OutfitContainer, "CENTER", -200, -75)
-TOM_PreviewModel_R2C1:EnableMouse(true)
-TOM_PreviewModel_R2C1:SetScript("OnMouseDown", TOM_PreviewModel_OnMouseDown)
-TOM_PreviewModel_R2C1:SetUnit("player")
-TOM_PreviewModel_R2C1.OutfitName = TOM_PreviewModel_R2C1:CreateFontString(nil, "OVERLAY", "GameTooltipText")
-TOM_PreviewModel_R2C1.OutfitName:ClearAllPoints()
-TOM_PreviewModel_R2C1.OutfitName:SetPoint("BOTTOM", TOM_PreviewModel_R2C1, "BOTTOM", 0, 10)
-TOM_PreviewModel_R2C1.OutfitName:Hide()
-TOM_PreviewModel_R2C1:Hide()
-TOM.previewModelFrames[5] = TOM_PreviewModel_R2C1
+TOM.PreviewModel_R2C1 = CreateFrame("DressUpModel", nil, TOM.OutfitContainer, "BackdropTemplate")
+TOM.PreviewModel_R2C1:SetSize(125, 175)
+TOM.PreviewModel_R2C1:SetBackdrop(backdrop)
+TOM.PreviewModel_R2C1:SetBackdropColor(0, 0, 0, 1)
+TOM.PreviewModel_R2C1:Show()
+TOM.PreviewModel_R2C1:SetPoint("CENTER", TOM.OutfitContainer, "CENTER", -200, -75)
+TOM.PreviewModel_R2C1:EnableMouse(true)
+TOM.PreviewModel_R2C1:SetScript("OnMouseDown", TOM.PreviewModel_OnMouseDown)
+TOM.PreviewModel_R2C1:SetUnit("player")
+TOM.PreviewModel_R2C1.OutfitName = TOM.PreviewModel_R2C1:CreateFontString(nil, "OVERLAY", "GameTooltipText")
+TOM.PreviewModel_R2C1.OutfitName:ClearAllPoints()
+TOM.PreviewModel_R2C1.OutfitName:SetPoint("BOTTOM", TOM.PreviewModel_R2C1, "BOTTOM", 0, 10)
+TOM.PreviewModel_R2C1.OutfitName:Hide()
+TOM.PreviewModel_R2C1:Hide()
+TOM.previewModelFrames[5] = TOM.PreviewModel_R2C1
 
 ------------------
 --ROW 2 COLUMN 2--
 ------------------
-TOM_PreviewModel_R2C2 = CreateFrame("DressUpModel", "TOM_PreviewModel_R2C2", TOM_OutfitContainer, "BackdropTemplate")
-TOM_PreviewModel_R2C2:SetSize(125, 175)
-TOM_PreviewModel_R2C2:SetBackdrop({bgFile="Interface/Tooltips/UI-Tooltip-Background",
-							edgeFile="Interface/Tooltips/UI-Tooltip-Border",
-							tile=true,
-							tileSize=16,
-							edgeSize=16,
-							insets={left=1,
-									right=1,
-									top=1,
-									bottom=1}
-})
-TOM_PreviewModel_R2C2:SetBackdropColor(0, 0, 0, 1)
-TOM_PreviewModel_R2C2:Show()
-TOM_PreviewModel_R2C2:SetPoint("CENTER", TOM_OutfitContainer, "CENTER", -65, -75)
-TOM_PreviewModel_R2C2:EnableMouse(true)
-TOM_PreviewModel_R2C2:SetScript("OnMouseDown", TOM_PreviewModel_OnMouseDown)
-TOM_PreviewModel_R2C2:SetUnit("player")
-TOM_PreviewModel_R2C2.OutfitName = TOM_PreviewModel_R2C2:CreateFontString(nil, "OVERLAY", "GameTooltipText")
-TOM_PreviewModel_R2C2.OutfitName:ClearAllPoints()
-TOM_PreviewModel_R2C2.OutfitName:SetPoint("BOTTOM", TOM_PreviewModel_R2C2, "BOTTOM", 0, 10)
-TOM_PreviewModel_R2C2.OutfitName:Hide()
-TOM_PreviewModel_R2C2:Hide()
-TOM.previewModelFrames[6] = TOM_PreviewModel_R2C2
+TOM.PreviewModel_R2C2 = CreateFrame("DressUpModel", nil, TOM.OutfitContainer, "BackdropTemplate")
+TOM.PreviewModel_R2C2:SetSize(125, 175)
+TOM.PreviewModel_R2C2:SetBackdrop(backdrop)
+TOM.PreviewModel_R2C2:SetBackdropColor(0, 0, 0, 1)
+TOM.PreviewModel_R2C2:Show()
+TOM.PreviewModel_R2C2:SetPoint("CENTER", TOM.OutfitContainer, "CENTER", -65, -75)
+TOM.PreviewModel_R2C2:EnableMouse(true)
+TOM.PreviewModel_R2C2:SetScript("OnMouseDown", TOM.PreviewModel_OnMouseDown)
+TOM.PreviewModel_R2C2:SetUnit("player")
+TOM.PreviewModel_R2C2.OutfitName = TOM.PreviewModel_R2C2:CreateFontString(nil, "OVERLAY", "GameTooltipText")
+TOM.PreviewModel_R2C2.OutfitName:ClearAllPoints()
+TOM.PreviewModel_R2C2.OutfitName:SetPoint("BOTTOM", TOM.PreviewModel_R2C2, "BOTTOM", 0, 10)
+TOM.PreviewModel_R2C2.OutfitName:Hide()
+TOM.PreviewModel_R2C2:Hide()
+TOM.previewModelFrames[6] = TOM.PreviewModel_R2C2
 
 ------------------
 --ROW 2 COLUMN 3--
 ------------------
-TOM_PreviewModel_R2C3 = CreateFrame("DressUpModel", "TOM_PreviewModel_R2C3", TOM_OutfitContainer, "BackdropTemplate")
-TOM_PreviewModel_R2C3:SetSize(125, 175)
-TOM_PreviewModel_R2C3:SetBackdrop({bgFile="Interface/Tooltips/UI-Tooltip-Background",
-							edgeFile="Interface/Tooltips/UI-Tooltip-Border",
-							tile=true,
-							tileSize=16,
-							edgeSize=16,
-							insets={left=1,
-									right=1,
-									top=1,
-									bottom=1}
-})
-TOM_PreviewModel_R2C3:SetBackdropColor(0, 0, 0, 1)
-TOM_PreviewModel_R2C3:Show()
-TOM_PreviewModel_R2C3:SetPoint("CENTER", TOM_OutfitContainer, "CENTER", 65, -75)
-TOM_PreviewModel_R2C3:EnableMouse(true)
-TOM_PreviewModel_R2C3:SetScript("OnMouseDown", TOM_PreviewModel_OnMouseDown)
-TOM_PreviewModel_R2C3:SetUnit("player")
-TOM_PreviewModel_R2C3.OutfitName = TOM_PreviewModel_R2C3:CreateFontString(nil, "OVERLAY", "GameTooltipText")
-TOM_PreviewModel_R2C3.OutfitName:ClearAllPoints()
-TOM_PreviewModel_R2C3.OutfitName:SetPoint("BOTTOM", TOM_PreviewModel_R2C3, "BOTTOM", 0, 10)
-TOM_PreviewModel_R2C3.OutfitName:Hide()
-TOM_PreviewModel_R2C3:Hide()
-TOM.previewModelFrames[7] = TOM_PreviewModel_R2C3
+TOM.PreviewModel_R2C3 = CreateFrame("DressUpModel", nil, TOM.OutfitContainer, "BackdropTemplate")
+TOM.PreviewModel_R2C3:SetSize(125, 175)
+TOM.PreviewModel_R2C3:SetBackdrop(backdrop)
+TOM.PreviewModel_R2C3:SetBackdropColor(0, 0, 0, 1)
+TOM.PreviewModel_R2C3:Show()
+TOM.PreviewModel_R2C3:SetPoint("CENTER", TOM.OutfitContainer, "CENTER", 65, -75)
+TOM.PreviewModel_R2C3:EnableMouse(true)
+TOM.PreviewModel_R2C3:SetScript("OnMouseDown", TOM.PreviewModel_OnMouseDown)
+TOM.PreviewModel_R2C3:SetUnit("player")
+TOM.PreviewModel_R2C3.OutfitName = TOM.PreviewModel_R2C3:CreateFontString(nil, "OVERLAY", "GameTooltipText")
+TOM.PreviewModel_R2C3.OutfitName:ClearAllPoints()
+TOM.PreviewModel_R2C3.OutfitName:SetPoint("BOTTOM", TOM.PreviewModel_R2C3, "BOTTOM", 0, 10)
+TOM.PreviewModel_R2C3.OutfitName:Hide()
+TOM.PreviewModel_R2C3:Hide()
+TOM.previewModelFrames[7] = TOM.PreviewModel_R2C3
 
 ------------------
 --ROW 2 COLUMN 4--
 ------------------
-TOM_PreviewModel_R2C4 = CreateFrame("DressUpModel", "TOM_PreviewModel_R2C4", TOM_OutfitContainer, "BackdropTemplate")
-TOM_PreviewModel_R2C4:SetSize(125, 175)
-TOM_PreviewModel_R2C4:SetBackdrop({bgFile="Interface/Tooltips/UI-Tooltip-Background",
-							edgeFile="Interface/Tooltips/UI-Tooltip-Border",
-							tile=true,
-							tileSize=16,
-							edgeSize=16,
-							insets={left=1,
-									right=1,
-									top=1,
-									bottom=1}
-})
-TOM_PreviewModel_R2C4:SetBackdropColor(0, 0, 0, 1)
-TOM_PreviewModel_R2C4:Show()
-TOM_PreviewModel_R2C4:SetPoint("CENTER", TOM_OutfitContainer, "CENTER", 200, -75)
-TOM_PreviewModel_R2C4:EnableMouse(true)
-TOM_PreviewModel_R2C4:SetScript("OnMouseDown", TOM_PreviewModel_OnMouseDown)
-TOM_PreviewModel_R2C4:SetUnit("player")
-TOM_PreviewModel_R2C4.OutfitName = TOM_PreviewModel_R2C4:CreateFontString(nil, "OVERLAY", "GameTooltipText")
-TOM_PreviewModel_R2C4.OutfitName:ClearAllPoints()
-TOM_PreviewModel_R2C4.OutfitName:SetPoint("BOTTOM", TOM_PreviewModel_R2C4, "BOTTOM", 0, 10)
-TOM_PreviewModel_R2C4.OutfitName:Hide()
-TOM_PreviewModel_R2C4:Hide()
-TOM.previewModelFrames[8] = TOM_PreviewModel_R2C4
+TOM.PreviewModel_R2C4 = CreateFrame("DressUpModel", nil, TOM.OutfitContainer, "BackdropTemplate")
+TOM.PreviewModel_R2C4:SetSize(125, 175)
+TOM.PreviewModel_R2C4:SetBackdrop(backdrop)
+TOM.PreviewModel_R2C4:SetBackdropColor(0, 0, 0, 1)
+TOM.PreviewModel_R2C4:Show()
+TOM.PreviewModel_R2C4:SetPoint("CENTER", TOM.OutfitContainer, "CENTER", 200, -75)
+TOM.PreviewModel_R2C4:EnableMouse(true)
+TOM.PreviewModel_R2C4:SetScript("OnMouseDown", TOM.PreviewModel_OnMouseDown)
+TOM.PreviewModel_R2C4:SetUnit("player")
+TOM.PreviewModel_R2C4.OutfitName = TOM.PreviewModel_R2C4:CreateFontString(nil, "OVERLAY", "GameTooltipText")
+TOM.PreviewModel_R2C4.OutfitName:ClearAllPoints()
+TOM.PreviewModel_R2C4.OutfitName:SetPoint("BOTTOM", TOM.PreviewModel_R2C4, "BOTTOM", 0, 10)
+TOM.PreviewModel_R2C4.OutfitName:Hide()
+TOM.PreviewModel_R2C4:Hide()
+TOM.previewModelFrames[8] = TOM.PreviewModel_R2C4

--- a/TOM_Util.lua
+++ b/TOM_Util.lua
@@ -1,4 +1,5 @@
-TOM = {}
+local addonName, TOM = ...
+
 TOM.DROPDOWN_RENAME = 1
 TOM.DROPDOWN_DELETE = 2
 TOM.SLOTID_TO_NAME = {
@@ -17,16 +18,16 @@ TOM.SLOTID_TO_NAME = {
 		[18] = "RANGEDSLOT",
 		[19] = "TABARDSLOT"
 }
-MyOutfits = {}
+TransmogOutfitManagerDB = TransmogOutfitManagerDB or {}
 
-function TOM_GetTransmogId(slot)
+function TOM.GetTransmogId(slot)
 	if slot.hasUndo then return tonumber(slot.base)
 	elseif slot.pending > 0 then return tonumber(slot.pending)
 	elseif slot.applied > 0 then return tonumber(slot.applied)
 	else return tonumber(slot.base) end
 end
 
-function TOM_IsValidName(name)
+function TOM.IsValidName(name)
 	local nameLength = string.len(name)
 	if nameLength == 0 or nameLength > 15 then
 		return false
@@ -35,16 +36,16 @@ function TOM_IsValidName(name)
 	end
 end
 
-function TOM_NumSavedOutfits()
+function TOM.NumSavedOutfits()
 	local count = 0
-	for _, outfit in pairs(MyOutfits) do
+	for _, outfit in pairs(TransmogOutfitManagerDB) do
 		if outfit.name then count = count + 1 end
 	end
 	return count
 end
 
-function TOM_OutfitExistsByName(name)
-	for _, outfit in pairs(MyOutfits) do
+function TOM.OutfitExistsByName(name)
+	for _, outfit in pairs(TransmogOutfitManagerDB) do
 		if outfit.name == name then return true end
 	end
 	return false

--- a/TOM_WardrobeFrame.lua
+++ b/TOM_WardrobeFrame.lua
@@ -1,8 +1,10 @@
+local addonName, TOM = ...
+
 local function TOM_OutfitsButton_OnClick(self, button, down)
-	if not TOM_OutfitContainer:IsVisible() then
-		TOM_OutfitContainer:Show()
+	if not TOM.OutfitContainer:IsVisible() then
+		TOM.OutfitContainer:Show()
 	else
-		TOM_OutfitContainer:Hide()
+		TOM.OutfitContainer:Hide()
 	end
 end
 
@@ -11,18 +13,18 @@ local function TOM_OutfitNameInput_OnEscapePressed(self)
 end
 
 local function TOM_OutfitNameInput_OnTextChanged(self, userInput)
-	TOM_SaveOutfitButton:SetEnabled(TOM_IsValidName(TOM_OutfitNameInput:GetText()))
+	TOM.SaveOutfitButton:SetEnabled(TOM.IsValidName(TOM.OutfitNameInput:GetText()))
 end
 
 local function TOM_SaveOutfitButton_OnClick(self, button, down)
-	local outfitName = TOM_OutfitNameInput:GetText()
+	local outfitName = TOM.OutfitNameInput:GetText()
 	if outfitName == "" then return end
 	local slotData = {}
 	for slotId, slotName in pairs(TOM.SLOTID_TO_NAME) do
 		local baseSourceID, _, appliedSourceID, _, pendingSourceID, _, hasUndo, _, _ = C_Transmog.GetSlotVisualInfo({slotID = slotId, type = 0, modification = 0})
 		slotData[slotName] = {base=baseSourceID, applied=appliedSourceID, pending=pendingSourceID, hasUndo=hasUndo}
 	end
-	if TOM_OutfitExistsByName(outfitName) then
+	if TOM.OutfitExistsByName(outfitName) then
 		StaticPopupDialogs["TOM_OverwriteOutfit"].text = "Overwrite \'" .. outfitName .. "\'?"
 		local dialog = StaticPopup_Show("TOM_OverwriteOutfit")
 		if dialog then
@@ -30,28 +32,28 @@ local function TOM_SaveOutfitButton_OnClick(self, button, down)
 			dialog.data2 = slotData
 		end
 	else
-		table.insert(MyOutfits, {name=outfitName, data=slotData})
+		table.insert(TransmogOutfitManagerDB, {name=outfitName, data=slotData})
 	end
-	TOM_OutfitContainer_OnShow()
+	TOM.OutfitContainer_OnShow()
 end
 
-TOM_OutfitsButton = CreateFrame("Button", "TOM_OutfitsButton", WardrobeFrame, "UIPanelButtonTemplate")
-TOM_OutfitsButton:ClearAllPoints()
-TOM_OutfitsButton:SetPoint("TOPLEFT", 3, -60)
-TOM_OutfitsButton:SetSize(60, 25)
-TOM_OutfitsButton:SetText("Outfits")
-TOM_OutfitsButton:SetScript("OnClick", TOM_OutfitsButton_OnClick)
+TOM.OutfitsButton = CreateFrame("Button", nil, WardrobeFrame, "UIPanelButtonTemplate")
+TOM.OutfitsButton:ClearAllPoints()
+TOM.OutfitsButton:SetPoint("TOPLEFT", 3, -60)
+TOM.OutfitsButton:SetSize(60, 25)
+TOM.OutfitsButton:SetText("Outfits")
+TOM.OutfitsButton:SetScript("OnClick", TOM_OutfitsButton_OnClick)
 
-TOM_OutfitNameInput = CreateFrame("EditBox", "TOM_OutfitNameInput", WardrobeFrame, "InputBoxTemplate")
-TOM_OutfitNameInput:ClearAllPoints()
-TOM_OutfitNameInput:SetPoint("TOPLEFT", 70, -55)
-TOM_OutfitNameInput:SetSize(175, 35)
-TOM_OutfitNameInput:SetAutoFocus(false)
-TOM_OutfitNameInput:SetScript("OnTextChanged", TOM_OutfitNameInput_OnTextChanged)
+TOM.OutfitNameInput = CreateFrame("EditBox", nil, WardrobeFrame, "InputBoxTemplate")
+TOM.OutfitNameInput:ClearAllPoints()
+TOM.OutfitNameInput:SetPoint("TOPLEFT", 70, -55)
+TOM.OutfitNameInput:SetSize(175, 35)
+TOM.OutfitNameInput:SetAutoFocus(false)
+TOM.OutfitNameInput:SetScript("OnTextChanged", TOM_OutfitNameInput_OnTextChanged)
 
-TOM_SaveOutfitButton = CreateFrame("Button", "TOM_SaveOutfitButton", WardrobeFrame, "UIPanelButtonTemplate")
-TOM_SaveOutfitButton:ClearAllPoints()
-TOM_SaveOutfitButton:SetPoint("TOPLEFT", 248, -60)
-TOM_SaveOutfitButton:SetSize(60, 25)
-TOM_SaveOutfitButton:SetText("Save")
-TOM_SaveOutfitButton:SetScript("OnClick", TOM_SaveOutfitButton_OnClick)
+TOM.SaveOutfitButton = CreateFrame("Button", nil, WardrobeFrame, "UIPanelButtonTemplate")
+TOM.SaveOutfitButton:ClearAllPoints()
+TOM.SaveOutfitButton:SetPoint("TOPLEFT", 248, -60)
+TOM.SaveOutfitButton:SetSize(60, 25)
+TOM.SaveOutfitButton:SetText("Save")
+TOM.SaveOutfitButton:SetScript("OnClick", TOM_SaveOutfitButton_OnClick)

--- a/TransmogOutfitManager.lua
+++ b/TransmogOutfitManager.lua
@@ -1,5 +1,7 @@
+local addonName, TOM = ...
+
 local function renameOutfit(newName)
-	for _, outfit in pairs(MyOutfits) do
+	for _, outfit in pairs(TransmogOutfitManagerDB) do
 		if outfit.name == TOM.activeModelFrame.OutfitName:GetText() then
 			TOM.activeModelFrame.OutfitName:SetText(newName)
 			outfit.name = newName
@@ -8,19 +10,19 @@ local function renameOutfit(newName)
 end
 
 local function deleteOutfit()
-	for i, outfit in ipairs(MyOutfits) do
-		if MyOutfits[i].name == TOM.activeModelFrame.OutfitName:GetText() then
-			table.remove(MyOutfits, i)
-			TOM_OutfitContainer_OnShow()
+	for i, outfit in ipairs(TransmogOutfitManagerDB) do
+		if TransmogOutfitManagerDB[i].name == TOM.activeModelFrame.OutfitName:GetText() then
+			table.remove(TransmogOutfitManagerDB, i)
+			TOM.OutfitContainer_OnShow()
 		end
 	end
 end
 
 local function overwriteOutfit(self, outfitName, slotData)
-	for _, outfit in pairs(MyOutfits) do
+	for _, outfit in pairs(TransmogOutfitManagerDB) do
 		if outfit.name == outfitName then
 			outfit.data = slotData
-			TOM_OutfitContainer_OnShow()
+			TOM.OutfitContainer_OnShow()
 		end
 	end
 end
@@ -35,7 +37,7 @@ StaticPopupDialogs["TOM_RenameOutfit"] = {
 		self.button1:Disable()
 	end,
 	EditBoxOnTextChanged = function(self, data)
-		if TOM_IsValidName(self:GetText()) then
+		if TOM.IsValidName(self:GetText()) then
 			self:GetParent().button1:Enable()
 		end
 	end,

--- a/TransmogOutfitManager.toc
+++ b/TransmogOutfitManager.toc
@@ -2,7 +2,7 @@
 ## Version: 1.1.0
 ## Title: TransmogOutfitManager
 ## Notes: Saves your custom transmogs as preset outfits
-## SavedVariablesPerCharacter: MyOutfits
+## SavedVariablesPerCharacter: TransmogOutfitManagerDB
 ## LoadOnDemand: 1
 ## LoadWith: Blizzard_Collections
 


### PR DESCRIPTION
![image](https://github.com/verkkila/TransmogOutfitManager/assets/109839/35765657-e917-410b-bca4-f881fbe76133)

Little proof I didn't cause regressions (break existing functionality)

Ok the discussion bit 😄 

Anything that is not defined as local is put in a global addon memory space in WoW Addons.
That makes it easy to break other addons (or the base UI) with name collisions.
It also exposes your addon to the same from other addons.

It is good practice to keep all the things that don't specifically need to be global self-contained (for example a globally accessible frame name is needed for using the `UISpecialFrames` array)

The same applies for saved variable arrays, they are also in the global namespace. In their case it cannot be avoided so a good practice is to make the saved variables array name unique.

Since you cannot have 2 addons named the same in your AddOns folder any combination of `YourAddonName`postfix is good.
`TransmogOutfitManagerDB` for example.

To help addon authors pass around variables and methods within their addon with no need to have everything in a monolithic .lua file they provide a special vararg that the WoW client passes into every .lua file loaded from the addon's .toc 

`local addonName, addon = ... ` at the top of any Lua file loaded by your .toc will get passed your addon name as a string and an array that is accessible by any other file in your addon but is __not__ put in the global namespace (that all addons share)

So it is essentially an "addon scope".

In this pull request I have used that to "tuck" all the unnecessary global functions neatly into your addon object `MOP`.

If you want something to be accessible globally you can still export it to the global environment but in a controlled way with a single (or few) access points.

For example `_G[addonName] = MOP` at the bottom of TOM_Util.lua would make everything tucked under MOP accessible from the outside under `TransmogOutfitManager`